### PR TITLE
ci(vuln): remediate GHA script injection

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -31,8 +31,9 @@ jobs:
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#release/}
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          VERSION=${BRANCH_NAME#release/}
+          VERSION="${BRANCH_NAME#release/}"
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout source branch


### PR DESCRIPTION
Replaces direct ${{ github.* }} interpolation in run: blocks with env: indirection. Prevents script injection RCE via crafted branch names or other user-controlled inputs. Ref: SEC-93.